### PR TITLE
Enable Angular standalone components

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { HomeComponent } from './home/home.component';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   imports: [HomeComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',

--- a/src/app/current-game/current-game.component.ts
+++ b/src/app/current-game/current-game.component.ts
@@ -4,6 +4,7 @@ import { ScoreComponent } from '../score/score.component';
 
 @Component({
   selector: 'app-current-game',
+  standalone: true,
   imports: [ScoreComponent],
   templateUrl: './current-game.component.html',
   styleUrl: './current-game.component.css',

--- a/src/app/game-actions-buttons/game-actions-buttons.component.ts
+++ b/src/app/game-actions-buttons/game-actions-buttons.component.ts
@@ -2,6 +2,7 @@ import { Component, output, Output } from '@angular/core';
 
 @Component({
   selector: 'app-game-actions-buttons',
+  standalone: true,
   imports: [],
   templateUrl: './game-actions-buttons.component.html',
   styleUrl: './game-actions-buttons.component.css',

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -9,6 +9,7 @@ import { IconsModule } from '../shared/icons.module';
 
 @Component({
   selector: 'app-home',
+  standalone: true,
   imports: [
     CurrentGameComponent,
     GameActionsButtonsComponent,

--- a/src/app/score-action-button/score-action-button.component.ts
+++ b/src/app/score-action-button/score-action-button.component.ts
@@ -3,6 +3,7 @@ import { ScoreTeam } from '../models/ScoreTeam';
 
 @Component({
   selector: 'app-score-action-button',
+  standalone: true,
   imports: [],
   templateUrl: './score-action-button.component.html',
   styleUrl: './score-action-button.component.css',

--- a/src/app/score/score.component.ts
+++ b/src/app/score/score.component.ts
@@ -4,6 +4,7 @@ import { ScoreActionButtonComponent } from '../score-action-button/score-action-
 
 @Component({
   selector: 'app-score',
+  standalone: true,
   imports: [ScoreActionButtonComponent],
   templateUrl: './score.component.html',
   styleUrl: './score.component.css',

--- a/src/app/timer/timer.component.ts
+++ b/src/app/timer/timer.component.ts
@@ -5,6 +5,7 @@ import { NgIcon } from '@ng-icons/core';
 
 @Component({
   selector: 'app-timer',
+  standalone: true,
   templateUrl: './timer.component.html',
   imports: [FormsModule, IconsModule, NgIcon],
 })


### PR DESCRIPTION
## Summary
- mark app components as standalone

## Testing
- `npm run build`
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6889c4bf5efc83308eaa351f08d0e934